### PR TITLE
Adjust yaml lint to allow for different sequence indent options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
           [
             "--no-warnings",
             "--config-data",
-            "{extends: default, rules: {line-length: disable, braces: {max-spaces-inside: 1}}}",
+            "{extends: default, rules: {line-length: disable, braces: {max-spaces-inside: 1}, indentation: {spaces: consistent, indent-sequences: whatever}}}",
           ]
         types: [text]
         files: \.(yml|yaml)$


### PR DESCRIPTION
Waypoints are written to the filesystem with no indent on sequences:

part of https://github.com/PickNikRobotics/moveit_pro/issues/11267
```
#waypoints
sequence:
- 1
- 2
- 3

# Other yaml files
sequence:
  - 1
  - 2
  - 3
```

Both are valid yaml. this yamllint config change allows for either option as long as it is consistent within the same file.